### PR TITLE
Version 1.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.gauck.sam'
-version '1.1.1'
+version '1.2.0'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/com/gauck/sam/Utilities/Utilities.java
+++ b/src/main/java/com/gauck/sam/Utilities/Utilities.java
@@ -113,5 +113,6 @@ public final class Utilities {
      */
     private static Set<String> profaneWords = new HashSet<>(Arrays.asList(
             "fuck", "shit", "bitch", "ass", "crap", "piss", "dick", "cock", "pussy",
-            "asshole", "fag", "bastard", "slut", "douche", "cunt", "damn", "pissed"));
+            "asshole", "fag", "bastard", "slut", "douche", "cunt", "damn", "pissed",
+            "fucker", "motherfucker", "dammit"));
 }

--- a/src/main/java/com/gauck/sam/Utilities/Utilities.java
+++ b/src/main/java/com/gauck/sam/Utilities/Utilities.java
@@ -75,7 +75,7 @@ public final class Utilities {
     public static String removeProfanity(String original) {
         if (original == null) return null;
         for (String bad : profaneWords) {
-            original = original.replaceAll("(?i)" + bad, clean(bad));
+            original = original.replaceAll("(?i)(?<![a-zA-Z])" + bad + "(?![a-zA-Z])", clean(bad));
         }
         return original;
     }
@@ -113,5 +113,5 @@ public final class Utilities {
      */
     private static Set<String> profaneWords = new HashSet<>(Arrays.asList(
             "fuck", "shit", "bitch", "ass", "crap", "piss", "dick", "cock", "pussy",
-            "asshole", "fag", "bastard", "slut", "douche", "cunt", "damn"));
+            "asshole", "fag", "bastard", "slut", "douche", "cunt", "damn", "pissed"));
 }

--- a/src/test/java/com/gauck/sam/Utilities/RemoveProfanityArrayListTest.java
+++ b/src/test/java/com/gauck/sam/Utilities/RemoveProfanityArrayListTest.java
@@ -23,7 +23,7 @@ public class RemoveProfanityArrayListTest {
 
     @Test
     public void removeProfanityFromCleanStringTest() {
-        ArrayList<String> list = new ArrayList<>(Collections.singleton("Sorry, Stringy"));
+        ArrayList<String> list = new ArrayList<>(Collections.singleton("Clean"));
         Assert.assertEquals(list, Utilities.removeProfanity(list));
     }
 
@@ -34,21 +34,21 @@ public class RemoveProfanityArrayListTest {
 
     @Test
     public void removeProfanityFromCleanStringAndCleanStringTest() {
-        ArrayList<String> list = new ArrayList<>(Arrays.asList("I didn't", "want to"));
+        ArrayList<String> list = new ArrayList<>(Arrays.asList("clean", "CLEAN"));
         Assert.assertEquals(list, Utilities.removeProfanity(list));
     }
 
     @Test
     public void removeProfanityFromCleanStringAndDirtyStringTest() {
-        ArrayList<String> list1 = new ArrayList<>(Arrays.asList("Do this", "Crap nuggets"));
-        ArrayList<String> list2 = new ArrayList<>(Arrays.asList("Do this", "**** nuggets"));
+        ArrayList<String> list1 = new ArrayList<>(Arrays.asList("clean", "Crap"));
+        ArrayList<String> list2 = new ArrayList<>(Arrays.asList("clean", "****"));
         Assert.assertEquals(list2, Utilities.removeProfanity(list1));
     }
 
     @Test
     public void removeProfanityFromDirtyStringAndDirtyStringTest() {
-        ArrayList<String> list1 = new ArrayList<>(Arrays.asList("Now I'm pissed off", "Shit, I'm sorry"));
-        ArrayList<String> list2 = new ArrayList<>(Arrays.asList("Now I'm ****ed off", "****, I'm sorry"));
+        ArrayList<String> list1 = new ArrayList<>(Arrays.asList("crap", "cRAp"));
+        ArrayList<String> list2 = new ArrayList<>(Arrays.asList("****", "****"));
         Assert.assertEquals(list2, Utilities.removeProfanity(list1));
     }
 }

--- a/src/test/java/com/gauck/sam/Utilities/RemoveProfanityStringTest.java
+++ b/src/test/java/com/gauck/sam/Utilities/RemoveProfanityStringTest.java
@@ -25,17 +25,57 @@ public class RemoveProfanityStringTest {
     }
 
     @Test
-    public void removeProfanityFromCleanStringTest() {
-        Assert.assertEquals("Any string that doesn't contain profanity", Utilities.removeProfanity("Any string that doesn't contain profanity"));
+    public void removeProfanityFromLowercaseCleanStringTest() {
+        Assert.assertEquals("clean", Utilities.removeProfanity("clean"));
     }
 
     @Test
-    public void removeProfanityFromDirtyStringTest() {
+    public void removeProfanityFromMixedCaseCleanStringTest() {
+        Assert.assertEquals("cLeAn", Utilities.removeProfanity("cLeAn"));
+    }
+
+    @Test
+    public void removeProfanityFromUppercaseCleanStringTest() {
+        Assert.assertEquals("CLEAN", Utilities.removeProfanity("CLEAN"));
+    }
+
+    @Test
+    public void removeProfanityFromLowercaseDirtyStringTest() {
         Assert.assertEquals("****", Utilities.removeProfanity("crap"));
     }
 
     @Test
+    public void removeProfanityFromMixedCaseDirtyStringTest() {
+        Assert.assertEquals("****", Utilities.removeProfanity("cRaP"));
+    }
+
+    @Test
+    public void removeProfanityFromUppercaseDirtyStringTest() {
+        Assert.assertEquals("****", Utilities.removeProfanity("CRAP"));
+    }
+
+    @Test
     public void removeProfanityFromInsidePartiallyDirtyStringTest() {
-        Assert.assertEquals("A****a", Utilities.removeProfanity("Acrapa"));
+        Assert.assertEquals("Acrapa", Utilities.removeProfanity("Acrapa"));
+    }
+
+    @Test
+    public void removeProfanityFromInsideUnderscoresTest() {
+        Assert.assertEquals("A_****_a", Utilities.removeProfanity("A_crap_a"));
+    }
+
+    @Test
+    public void removeProfanityFromInsideHypensTest() {
+        Assert.assertEquals("A-****-a", Utilities.removeProfanity("A-crap-a"));
+    }
+
+    @Test
+    public void removeProfanityFromInsidePeriodsTest() {
+        Assert.assertEquals("A.****.a", Utilities.removeProfanity("A.crap.a"));
+    }
+
+    @Test
+    public void removeProfanityFromInsideNumbersTest() {
+        Assert.assertEquals("A1****1a", Utilities.removeProfanity("A1crap1a"));
     }
 }


### PR DESCRIPTION
- Stops replacing profanity that is part of a word (e.g. `associates` became `***ociates`) (issue #4)
- Adds more profane words due to less replacement (e.g. [here](https://github.com/Samasaur1/Utilities/compare/development?expand=1#diff-a87ce3808cc4207e7f7b7d46b800e2bbL116))