### PR TITLE
Convert ArrayList to List in removeProfanity

### DIFF
--- a/src/main/java/com/gauck/sam/Utilities/Utilities.java
+++ b/src/main/java/com/gauck/sam/Utilities/Utilities.java
@@ -84,20 +84,21 @@ public final class Utilities {
     }
 
     /**
-     * Removes profanity from every string in a given ArrayList.
-     * Strings that are either empty or null will be returned unchanged. If the ArrayList is empty or null, it will be returned unchanged.
+     * Removes profanity from every string in a given List.
+     * Strings that are either empty or null will be returned unchanged. If the List is empty or null, it will be returned unchanged.
      * <p>
-     * For every string in this ArrayList, the {@link #removeProfanity(String)} method is called on it.
+     * For every string in this List, the {@link #removeProfanity(String)} method is called on it.
      *
-     * @param original The ArrayList to 'clean'. If this is null, this method returns null. If it is empty, it is returned unchanged.
-     * @return The cleaned ArrayList. Each string in it has been cleansed.
+     * @param original The List to 'clean'. If this is null, this method returns null. If it is empty, it is returned unchanged.
+     * @return The cleaned List. Each string in it has been cleansed.
      * @see #removeProfanity(String)
      */
-    public static ArrayList<String> removeProfanity(ArrayList<String> original) {
-        if (original == null) return null;
-        for (int i = 0; i < original.size(); i++) {
-            original.set(i, removeProfanity(original.get(i)));
-        }
+    public static <ListType extends Collection<String>> ListType removeProfanity(ListType original) {
+        original.forEach(string -> {
+            original.remove(string);
+            string = removeProfanity(string);
+            original.add(string);
+        });
         return original;
     }
 

--- a/src/main/java/com/gauck/sam/Utilities/Utilities.java
+++ b/src/main/java/com/gauck/sam/Utilities/Utilities.java
@@ -93,7 +93,7 @@ public final class Utilities {
      * @return The cleaned List. Each string in it has been cleansed.
      * @see #removeProfanity(String)
      */
-    public static <ListType extends List<String>> ListType removeProfanity(ListType original) {
+    public static List<String> removeProfanity(List<String> original) {
         if (original == null) return null;
         for (int i = 0; i < original.size(); i++) {
             original.set(i, removeProfanity(original.get(i)));

--- a/src/main/java/com/gauck/sam/Utilities/Utilities.java
+++ b/src/main/java/com/gauck/sam/Utilities/Utilities.java
@@ -93,12 +93,11 @@ public final class Utilities {
      * @return The cleaned List. Each string in it has been cleansed.
      * @see #removeProfanity(String)
      */
-    public static <ListType extends Collection<String>> ListType removeProfanity(ListType original) {
-        original.forEach(string -> {
-            original.remove(string);
-            string = removeProfanity(string);
-            original.add(string);
-        });
+    public static <ListType extends List<String>> ListType removeProfanity(ListType original) {
+        if (original == null) return null;
+        for (int i = 0; i < original.size(); i++) {
+            original.set(i, removeProfanity(original.get(i)));
+        }
         return original;
     }
 

--- a/src/test/java/com/gauck/sam/Utilities/RemoveProfanityListTest.java
+++ b/src/test/java/com/gauck/sam/Utilities/RemoveProfanityListTest.java
@@ -6,13 +6,13 @@ import org.junit.Test;
 import java.util.*;
 
 /**
- * Unit tests for the {@link Utilities} removeProfanity(ArrayList<String> original) function.
+ * Unit tests for the {@link Utilities} removeProfanity(List original) function.
  *
  * @author Samasaur
  */
-public class RemoveProfanityArrayListTest {
+public class RemoveProfanityListTest {
     @Test
-    public void removeProfanityFromEmptyArrayListTest() {
+    public void removeProfanityFromEmptyListTest() {
         Assert.assertEquals(new ArrayList<String>(), Utilities.removeProfanity(new ArrayList<>()));
     }
 


### PR DESCRIPTION
Pretty self-evident. This PR uses generics to allow the calling of `removeProfanity` with any `List`, not just `ArrayList`s.